### PR TITLE
Accept RST.LIS as a valid instruction

### DIFF
--- a/src/instruction.c
+++ b/src/instruction.c
@@ -572,7 +572,7 @@ operandlist operands_rsmix[] = {
     {OPTYPE_NONE, OPTYPE_NONE,          false, TRANSFORM_NONE,   TRANSFORM_NONE, 0xED, 0x7E, S_NONE},
 };
 operandlist operands_rst[] = {
-    {OPTYPE_N, OPTYPE_NONE,             false, TRANSFORM_N,      TRANSFORM_NONE, 0x00, 0xC7, S_SISLIL},
+    {OPTYPE_N, OPTYPE_NONE,             false, TRANSFORM_N,      TRANSFORM_NONE, 0x00, 0xC7, S_ANY},
 };
 operandlist operands_sbc[] = {
     {OPTYPE_A, OPTYPE_INDIRECT_HL,      false, TRANSFORM_NONE,   TRANSFORM_NONE, 0x00, 0x9E, S_S1L0},


### PR DESCRIPTION
Possibly fixes issue #18

My program at least assembles! I haven't had a chance to test it, though (I'm converting from spasm-ng and not quite there yet :-))