### PR TITLE
Resolve build errors on Windows / MSVC

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,9 @@
 #define CONFIG_H
 
 #ifndef UNIX
+#ifndef _MSC_VER
 #define AGON
+#endif
 #endif // UNIX
 
 #ifdef _MSC_VER

--- a/src/main.c
+++ b/src/main.c
@@ -11,7 +11,7 @@
 #include "mos_posix.h"
 #include "malloc.h"
 #include "io.h"
-#include <getopt.h>
+#include "getopt.h"
 #include "str2num.h"
 #include "label.h"
 //#include <time.h>


### PR DESCRIPTION
A couple of small fixes to ensure the sources can be build without errors on Windows using Microsoft Visual C++ 2022 compiler.